### PR TITLE
Make alert results public so they can be consumed

### DIFF
--- a/src/result_types.rs
+++ b/src/result_types.rs
@@ -459,5 +459,5 @@ pub struct Alert {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Alerts {
-    alerts: Vec<Alert>,
+    pub alerts: Vec<Alert>,
 }


### PR DESCRIPTION
I tried to build something with this crate and it was going great. At some point I wanted to access the alerts and figured out that the field wasn't public. Probably an oversight. This PR makes the `alerts` field of the `Alerts` struct in the result types public.